### PR TITLE
Implement creation from `color.Color` interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ two players got very similar colors, which bugged me. The very same evening,
 [I want hue](http://tools.medialab.sciences-po.fr/iwanthue/) was the top post
 on HackerNews' frontpage and showed me how to Do It Right™. Last but not
 least, there was no library for handling color spaces available in go. Colorful
-does just that and implements Go's color.Color interface.
+does just that and implements Go's `color.Color` interface.
 
 What?
 =====
@@ -118,6 +118,17 @@ h, c, l := c.Hcl()
 Note that, because of Go's unfortunate choice of requiring an initial uppercase,
 the name of the functions relating to the xyY space are just off. If you have
 any good suggestion, please open an issue. (I don't consider XyY good.)
+
+### The `color.Color` interface
+Because a `colorful.Color` implements Go's `color.Color` interface (found in the
+`image/color` package), it can be used anywhere that expects a `color.Color`.
+
+Furthermore, you can convert anything that implements the `color.Color` interface
+into a `colorful.Color` using the `MakeColorful` function:
+
+```go
+c := colorful.MakeColor(color.Gray16{12345})
+```
 
 ### Comparing colors
 In the RGB color space, the Euclidian distance between colors *doesn't* correspond

--- a/colors.go
+++ b/colors.go
@@ -4,6 +4,7 @@ package colorful
 import(
     "fmt"
     "math"
+    "image/color"
 )
 
 // A color is stored internally using sRGB (standard RGB) values in the range 0-1
@@ -18,6 +19,22 @@ func (col Color) RGBA() (r, g, b, a uint32) {
     b = uint32(col.B*65535.0+0.5)
     a = 0xFFFF
     return
+}
+
+// Constructs a colorful.Color from something implementing color.Color
+func MakeColor(col color.Color) Color {
+    r, g, b, a := col.RGBA()
+
+    // Since color.Color is alpha pre-multiplied, we need to divide the
+    // RGB values by alpha again in order to get back the original RGB.
+    r *= 0xffff
+    r /= a
+    g *= 0xffff
+    g /= a
+    b *= 0xffff
+    b /= a
+
+    return Color{float64(r)/65535.0, float64(g)/65535.0, float64(b)/65535.0}
 }
 
 // Might come in handy sometimes to reduce boilerplate code.

--- a/colors_test.go
+++ b/colors_test.go
@@ -4,6 +4,7 @@ import (
     "math"
     "strings"
     "testing"
+    "image/color"
 )
 
 // Checks whether the relative error is below eps
@@ -407,6 +408,36 @@ func TestClamp(t *testing.T) {
     c_want := Color{1.0, 0.0, 0.5}
     if c_orig.Clamped() != c_want {
         t.Errorf("%v.Clamped() => %v, want %v", c_orig, c_orig.Clamped(), c_want)
+    }
+}
+
+func TestMakeColor(t *testing.T) {
+    c_orig_nrgba := color.NRGBA{123, 45, 67, 255}
+    c_ours := MakeColor(c_orig_nrgba)
+    r, g, b := c_ours.RGB255()
+    if r != 123 || g != 45 || b != 67 {
+        t.Errorf("NRGBA->Colorful->RGB255 error: %v became (%v, %v, %v)", c_orig_nrgba, r, g, b)
+    }
+
+    c_orig_nrgba64 := color.NRGBA64{123 << 8, 45 << 8, 67 << 8, 0xffff}
+    c_ours = MakeColor(c_orig_nrgba64)
+    r, g, b = c_ours.RGB255()
+    if r != 123 || g != 45 || b != 67 {
+        t.Errorf("NRGBA64->Colorful->RGB255 error: %v became (%v, %v, %v)", c_orig_nrgba64, r, g, b)
+    }
+
+    c_orig_gray := color.Gray{123}
+    c_ours = MakeColor(c_orig_gray)
+    r, g, b = c_ours.RGB255()
+    if r != 123 || g != 123 || b != 123 {
+        t.Errorf("Gray->Colorful->RGB255 error: %v became (%v, %v, %v)", c_orig_gray, r, g, b)
+    }
+
+    c_orig_gray16 := color.Gray16{123 << 8}
+    c_ours = MakeColor(c_orig_gray16)
+    r, g, b = c_ours.RGB255()
+    if r != 123 || g != 123 || b != 123 {
+        t.Errorf("Gray16->Colorful->RGB255 error: %v became (%v, %v, %v)", c_orig_gray16, r, g, b)
     }
 }
 


### PR DESCRIPTION
This is a more general (but a little slower) method than what was proposed in issue #17 by @ZirconiumX.