### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/lucasb-eyer/go-colorful
+
+go 1.9
+
+require gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2, and doesn't have many dependencies the `go.mod` file is fairly simple. The only other thing that would need to happen is that future releases would need to have semver compatible tags. If you choose to merge this PR, please tag the merge commit as `v1.0.1` or similar so that users can pin to the new tagged version with the go.mod file instead of relying on the special compatibility imports.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules