### PR TITLE
Update sqlmock dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/lucasb-eyer/go-colorful
 
-go 1.9
+go 1.12
 
-require gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
+require github.com/DATA-DOG/go-sqlmock v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
-gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=


### PR DESCRIPTION
go-sqlmock have switched from gopkg.in to Go modules. This repository uses the
new github.com import path, however the go.mod file still uses the old gopkg.in
import path. This confuses `go mod` when importing this package:

    go: gopkg.in/DATA-DOG/go-sqlmock.v1@v1.3.3: go.mod has non-....v1 module path "github.com/DATA-DOG/go-sqlmock" at revision v1.3.3

This commit updates the go.mod import path.

(Please tag a new minor version after merging this)