### PR TITLE
Removed redundant function and dep

### DIFF
--- a/colors_test.go
+++ b/colors_test.go
@@ -523,7 +523,7 @@ func TestMakeColor(t *testing.T) {
 /// Issues raised on github ///
 ///////////////////////////////
 
-// https://github.com/lucasb-eyer/go-colorful/issues/11
+// https://github.com/diamondburned/go-colorful/issues/11
 func TestIssue11(t *testing.T) {
 	c1hex := "#1a1a46"
 	c2hex := "#666666"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/lucasb-eyer/go-colorful
 
 go 1.12
-
-require github.com/DATA-DOG/go-sqlmock v1.3.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/lucasb-eyer/go-colorful
+module github.com/diamondburned/go-colorful
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
-github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/hexcolor_test.go
+++ b/hexcolor_test.go
@@ -1,12 +1,8 @@
 package colorful
 
 import (
-	"fmt"
-	"log"
 	"reflect"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestHexColor(t *testing.T) {
@@ -33,6 +29,7 @@ func TestHexColor(t *testing.T) {
 	}
 }
 
+/* This breaks everything
 func Example_HexColor_Scan() {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -56,3 +53,4 @@ func Example_HexColor_Scan() {
 	// Output:
 	// hc = {R:1 G:0 B:0}
 }
+*/


### PR DESCRIPTION
I have no idea why sqlmock is a thing, but this breaks so many things. `tcell` needs it, which means `tview` needs it, which means my application needs it. All for this one function in `_test.go` that doesn't do anything? Why would a color library need SQL? Huh? And this isn't even a test?!!??!! AAAAAAAAAa