### PR TITLE
Simplify Go code

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -245,7 +245,7 @@ func Hsl(h, s, l float64) Color {
 	}
 
 	t2 = 2*l - t1
-	h = h / 360
+	h /= 360
 	tr = h + 1.0/3.0
 	tg = h
 	tb = h - 1.0/3.0


### PR DESCRIPTION
`h /= x` instead of `h = h / x`.