### PR TITLE
Remove sqlmock dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 install:
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/DATA-DOG/go-sqlmock
   - go get github.com/mattn/goveralls
 script:
   - go test -v -covermode=count -coverprofile=coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/lucasb-eyer/go-colorful
 
 go 1.12
-
-require github.com/DATA-DOG/go-sqlmock v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
-github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=

--- a/hexcolor_test.go
+++ b/hexcolor_test.go
@@ -1,12 +1,8 @@
 package colorful
 
 import (
-	"fmt"
-	"log"
 	"reflect"
 	"testing"
-
-	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestHexColor(t *testing.T) {
@@ -31,28 +27,4 @@ func TestHexColor(t *testing.T) {
 			t.Errorf("%v.Value() == %v, %v, want %v, <nil>", tc.hc, gotValue, err, tc.s)
 		}
 	}
-}
-
-func Example_HexColor_Scan() {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-
-	mock.ExpectQuery("SELECT '#ff0000' AS color;").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"color"}).
-				AddRow("#ff0000"),
-		)
-
-	var hc HexColor
-	if err := db.QueryRow("SELECT '#ff0000' AS color;").Scan(&hc); err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Printf("hc = %+v\n", hc)
-
-	// Output:
-	// hc = {R:1 G:0 B:0}
 }


### PR DESCRIPTION
Per https://github.com/lucasb-eyer/go-colorful/issues/38 discussion,
remove the dependency on DATA-DOG/go-sqlmock, as it's only used for
the runnable example in hexcolor_test.go, and introduces an
unnecessary dependency on an SQL mocking library as well as adding
commit noise when upgrading dependencies.