### PR TITLE
Fix hex overflow on RGB values outside of [0,1]

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -357,7 +357,7 @@ func Hsl(h, s, l float64) Color {
 // Hex returns the hex "html" representation of the color, as in #ff0080.
 func (col Color) Hex() string {
 	// Add 0.5 for rounding
-	return fmt.Sprintf("#%02x%02x%02x", uint8(col.R*255.0+0.5), uint8(col.G*255.0+0.5), uint8(col.B*255.0+0.5))
+	return fmt.Sprintf("#%02x%02x%02x", uint8(clamp01(col.R)*255.0+0.5), uint8(clamp01(col.G)*255.0+0.5), uint8(clamp01(col.B)*255.0+0.5))
 }
 
 // Hex parses a "html" hex color-string, either in the 3 "#f0c" or 6 "#ff1034" digits form.

--- a/colors_test.go
+++ b/colors_test.go
@@ -645,3 +645,22 @@ func TestInterpolation(t *testing.T) {
 		}
 	}
 }
+
+func TestHexOverflow(t *testing.T) {
+	// Converting LUV to RGB can result in R, G, or B values below 0 or greater than 1.
+	// This causes problems especially when converting those RGB values to hex.
+	// A RGB value below 0 should be represented as 0,
+	// one above 1 should be represented as 1
+	for _, tc := range []struct {
+		color       Color
+		expectedHex string
+	}{
+		{color: Color{1.1, 1.0, 1.0}, expectedHex: "#ffffff"},
+		{color: Color{-0.1, 0.0, 0.0}, expectedHex: "#000000"},
+	} {
+		res := tc.color.Hex()
+		if res != tc.expectedHex {
+			t.Errorf("Hex(%v) => (%v), want %v", tc.color, res, tc.expectedHex)
+		}
+	}
+}


### PR DESCRIPTION
When an RGB color with values either above 1 or below zero is converted to hex, the unit8 overflows and wraps around.

Values below 0 become FF and decreasing,
Values above 1 become 00 and increasing.

These RGB values can result from LUV colors outside the RGB space being converted into RGB. To preseve the LUV space, apparently it was decided that RGB values outside of [0,1] are acceptable (to represent the RGB color without loss), but especially when rendering to hex these overflowing values become a problem.

**A color "more red" than 100% RGB red should not be black, but RGB 100% red, instead.
A yellow that is just a little bit more red than FFFF00 should not be green (00FF00) suddenly, but instead the best yellow we can get out of RGB, which is FFFF00.**

**-> Clamping the RGB values before hex conversion solves this without losing the information in the Color object.**

The PR contains a commit with a failing test that illustrates this behavior, and one with a fix.
