### PR TITLE
Fix warning 'Restore cache failed'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         go-version: ["1.13", "1.21", "1.22", "1.23"]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod


### PR DESCRIPTION
The GitHub `test` action produces a [warning](https://github.com/lucasb-eyer/go-colorful/actions/runs/10474177618):

```
Restore cache failed: Dependencies file is not found in /home/runner/work/go-colorful/go-colorful.
Supported file pattern: go.sum
```

This PR fixes that issue.

