### PR TITLE
perf: a faster implementation of Hex()

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image/color"
 	"math"
+	"strconv"
 )
 
 // A color is stored internally using sRGB (standard RGB) values in the range 0-1
@@ -364,23 +365,46 @@ func (col Color) Hex() string {
 
 // Hex parses a "html" hex color-string, either in the 3 "#f0c" or 6 "#ff1034" digits form.
 func Hex(scol string) (Color, error) {
-	format := "#%02x%02x%02x"
-	factor := 1.0 / 255.0
-	if len(scol) == 4 {
-		format = "#%1x%1x%1x"
-		factor = 1.0 / 15.0
-	}
-
-	var r, g, b uint8
-	n, err := fmt.Sscanf(scol, format, &r, &g, &b)
-	if err != nil {
-		return Color{}, err
-	}
-	if n != 3 {
+	if scol[0] != '#' {
 		return Color{}, fmt.Errorf("color: %v is not a hex-color", scol)
 	}
+	var c Color
+	var err error
+	switch len(scol) {
+	case 4:
+		c, err = parseHexColor(scol[1:2], scol[2:3], scol[3:4], 4, 1.0/15.0)
+	case 7:
+		c, err = parseHexColor(scol[1:3], scol[3:5], scol[5:7], 8, 1.0/255.0)
+	default:
+		return Color{}, fmt.Errorf("color: %v is not a hex-color", scol)
+	}
+	if err != nil {
+		return Color{}, fmt.Errorf("color: %v is not a hex-color: %w", scol, err)
+	}
+	return c, nil
+}
 
-	return Color{float64(r) * factor, float64(g) * factor, float64(b) * factor}, nil
+func parseHexColor(r, g, b string, bits int, factor float64) (Color, error) {
+	var c Color
+	var v uint64
+	var err error
+
+	if v, err = strconv.ParseUint(r, 16, bits); err != nil {
+		return Color{}, err
+	}
+	c.R = float64(v) * factor
+
+	if v, err = strconv.ParseUint(g, 16, bits); err != nil {
+		return Color{}, err
+	}
+	c.G = float64(v) * factor
+
+	if v, err = strconv.ParseUint(b, 16, bits); err != nil {
+		return Color{}, err
+	}
+	c.B = float64(v) * factor
+
+	return c, err
 }
 
 /// Linear ///

--- a/colors.go
+++ b/colors.go
@@ -365,7 +365,7 @@ func (col Color) Hex() string {
 
 // Hex parses a "html" hex color-string, either in the 3 "#f0c" or 6 "#ff1034" digits form.
 func Hex(scol string) (Color, error) {
-	if scol[0] != '#' {
+	if scol == "" || scol[0] != '#' {
 		return Color{}, fmt.Errorf("color: %v is not a hex-color", scol)
 	}
 	var c Color

--- a/colors_test.go
+++ b/colors_test.go
@@ -199,6 +199,15 @@ func TestHexConversion(t *testing.T) {
 	}
 }
 
+func BenchmarkHex(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := Hex("#FFFFFF"); err != nil {
+			b.Errorf("Hex failed: %v", err)
+		}
+	}
+}
+
 /// Linear ///
 //////////////
 


### PR DESCRIPTION
While I was benchmarking my bubble tea application, I noticed that it was spending almost 40% of its time in go-colorful's Hex function, and specifically in the fmt.Sscanf function.

This PR implements Hex() without relying on fmt.Sscanf, but instead performs its own parsing. All tests pass.

The performance improvement is substantial:

```
before: BenchmarkHex-10    	 3761415	       319.4 ns/op	      74 B/op	       6 allocs/op
after:  BenchmarkHex-10    	90607219	       12.50 ns/op	       0 B/op	       0 allocs/op
```

Not only is it significantly faster. It also does not perform any allocations. 

The impact on my own application is also significant: in the current implementation, it spent about 40% of the time in Hex().  Now this is down to less than 5%:

```
before: BenchmarkTable_View/styled-10         	     921	   1433068 ns/op	  272142 B/op	   11766 allocs/op
after:  BenchmarkTable_View/styled-10         	    1525	    782587 ns/op	   75496 B/op	    1566 allocs/op
```

Comments are welcome! :)
