### PR TITLE
Add CSS Color Level 4 wide-gamut RGB color spaces and XYZ D50

### DIFF
--- a/widegamut.go
+++ b/widegamut.go
@@ -1,0 +1,290 @@
+package colorful
+
+import "math"
+
+// Wide-gamut RGB color spaces from CSS Color Level 4.
+// https://www.w3.org/TR/css-color-4/#color-conversion-code
+
+/// Bradford ///
+////////////////
+// Bradford chromatic adaptation between D50 and D65 illuminants.
+
+func D50ToD65(x, y, z float64) (xo, yo, zo float64) {
+	xo = 0.9555766*x - 0.0230393*y + 0.0631636*z
+	yo = -0.0282895*x + 1.0099416*y + 0.0210077*z
+	zo = 0.0122982*x - 0.0204830*y + 1.3299098*z
+	return
+}
+
+func D65ToD50(x, y, z float64) (xo, yo, zo float64) {
+	xo = 1.0479298208405488*x + 0.022946793341019088*y - 0.05019222954313557*z
+	yo = 0.029627815688159344*x + 0.990434484573249*y - 0.01707382502938514*z
+	zo = -0.009243058152591178*x + 0.015055144896577895*y + 0.7518742899580008*z
+	return
+}
+
+/// XYZ D50 ///
+///////////////
+
+func XyzD50(x, y, z float64) Color {
+	return Xyz(D50ToD65(x, y, z))
+}
+
+func (col Color) XyzD50() (x, y, z float64) {
+	return D65ToD50(col.Xyz())
+}
+
+/// Display P3 ///
+//////////////////
+// Uses the sRGB transfer function with DCI-P3 primaries.
+
+func DisplayP3ToLinearRgb(r, g, b float64) (rl, gl, bl float64) {
+	rl = linearize(r)
+	gl = linearize(g)
+	bl = linearize(b)
+	return
+}
+
+func LinearDisplayP3ToXyz(r, g, b float64) (x, y, z float64) {
+	x = 0.4865709486482162*r + 0.26566769316909306*g + 0.1982172852343625*b
+	y = 0.2289745640697488*r + 0.6917385218365064*g + 0.079286914093745*b
+	z = 0.04511338185890264*g + 1.043944368900976*b
+	return
+}
+
+func XyzToLinearDisplayP3(x, y, z float64) (r, g, b float64) {
+	r = 2.493496911941425*x - 0.9313836179191239*y - 0.40271078445071684*z
+	g = -0.8294889695615747*x + 1.7626640603183463*y + 0.023624685841943577*z
+	b = 0.035845830243784335*x - 0.07617238926804182*y + 0.9568845240076872*z
+	return
+}
+
+func DisplayP3(r, g, b float64) Color {
+	rl, gl, bl := DisplayP3ToLinearRgb(r, g, b)
+	x, y, z := LinearDisplayP3ToXyz(rl, gl, bl)
+	return Xyz(x, y, z)
+}
+
+func (col Color) DisplayP3() (r, g, b float64) {
+	x, y, z := col.Xyz()
+	rl, gl, bl := XyzToLinearDisplayP3(x, y, z)
+	r = delinearize(rl)
+	g = delinearize(gl)
+	b = delinearize(bl)
+	return
+}
+
+// BlendDisplayP3 blends two colors in the Display P3 color-space.
+// t == 0 results in c1, t == 1 results in c2
+func (c1 Color) BlendDisplayP3(c2 Color, t float64) Color {
+	r1, g1, b1 := c1.DisplayP3()
+	r2, g2, b2 := c2.DisplayP3()
+	return DisplayP3(
+		r1+t*(r2-r1),
+		g1+t*(g2-g1),
+		b1+t*(b2-b1))
+}
+
+/// A98 RGB ///
+///////////////
+// Adobe RGB (1998) color space.
+
+func linearizeA98(v float64) float64 {
+	sign := 1.0
+	if v < 0 {
+		sign = -1.0
+		v = -v
+	}
+	return sign * math.Pow(v, 563.0/256.0)
+}
+
+func delinearizeA98(v float64) float64 {
+	sign := 1.0
+	if v < 0 {
+		sign = -1.0
+		v = -v
+	}
+	return sign * math.Pow(v, 256.0/563.0)
+}
+
+func A98RgbToLinearRgb(r, g, b float64) (rl, gl, bl float64) {
+	rl = linearizeA98(r)
+	gl = linearizeA98(g)
+	bl = linearizeA98(b)
+	return
+}
+
+func LinearA98RgbToXyz(r, g, b float64) (x, y, z float64) {
+	x = 0.5766690429101305*r + 0.1855582379065463*g + 0.1882286462349947*b
+	y = 0.29734497525053605*r + 0.6273635662554661*g + 0.07529145849399788*b
+	z = 0.02703136138641234*r + 0.07068885253582723*g + 0.9913375368376388*b
+	return
+}
+
+func XyzToLinearA98Rgb(x, y, z float64) (r, g, b float64) {
+	r = 2.0415879038107327*x - 0.5650069742788597*y - 0.34473135077832956*z
+	g = -0.9692436362808795*x + 1.8759675015077202*y + 0.04155505740717559*z
+	b = 0.013444280632031142*x - 0.11836239223101838*y + 1.0151749943912054*z
+	return
+}
+
+func A98Rgb(r, g, b float64) Color {
+	rl, gl, bl := A98RgbToLinearRgb(r, g, b)
+	x, y, z := LinearA98RgbToXyz(rl, gl, bl)
+	return Xyz(x, y, z)
+}
+
+func (col Color) A98Rgb() (r, g, b float64) {
+	x, y, z := col.Xyz()
+	rl, gl, bl := XyzToLinearA98Rgb(x, y, z)
+	r = delinearizeA98(rl)
+	g = delinearizeA98(gl)
+	b = delinearizeA98(bl)
+	return
+}
+
+// BlendA98Rgb blends two colors in the A98 RGB color-space.
+// t == 0 results in c1, t == 1 results in c2
+func (c1 Color) BlendA98Rgb(c2 Color, t float64) Color {
+	r1, g1, b1 := c1.A98Rgb()
+	r2, g2, b2 := c2.A98Rgb()
+	return A98Rgb(
+		r1+t*(r2-r1),
+		g1+t*(g2-g1),
+		b1+t*(b2-b1))
+}
+
+/// ProPhoto RGB ///
+////////////////////
+// ProPhoto RGB (ROMM RGB) uses D50 illuminant.
+
+func linearizeProPhoto(v float64) float64 {
+	if v <= 16.0/512.0 {
+		return v / 16.0
+	}
+	return math.Pow(v, 1.8)
+}
+
+func delinearizeProPhoto(v float64) float64 {
+	if v < 1.0/512.0 {
+		return 16.0 * v
+	}
+	return math.Pow(v, 1.0/1.8)
+}
+
+func ProPhotoRgbToLinearRgb(r, g, b float64) (rl, gl, bl float64) {
+	rl = linearizeProPhoto(r)
+	gl = linearizeProPhoto(g)
+	bl = linearizeProPhoto(b)
+	return
+}
+
+func LinearProPhotoRgbToXyzD50(r, g, b float64) (x, y, z float64) {
+	x = 0.7977604896723027*r + 0.13518583717574031*g + 0.0313493495815248*b
+	y = 0.2880711282292934*r + 0.7118432178101014*g + 0.00008565396060525902*b
+	z = 0.8251046025104602 * b
+	return
+}
+
+func XyzD50ToLinearProPhotoRgb(x, y, z float64) (r, g, b float64) {
+	r = 1.3457989731028281*x - 0.25558010007997534*y - 0.05110628506753401*z
+	g = -0.5446224939028347*x + 1.5082327413132781*y + 0.02053603239147973*z
+	b = 1.2119675456389454 * z
+	return
+}
+
+func ProPhotoRgb(r, g, b float64) Color {
+	rl, gl, bl := ProPhotoRgbToLinearRgb(r, g, b)
+	x, y, z := LinearProPhotoRgbToXyzD50(rl, gl, bl)
+	return XyzD50(x, y, z)
+}
+
+func (col Color) ProPhotoRgb() (r, g, b float64) {
+	x, y, z := col.XyzD50()
+	rl, gl, bl := XyzD50ToLinearProPhotoRgb(x, y, z)
+	r = delinearizeProPhoto(rl)
+	g = delinearizeProPhoto(gl)
+	b = delinearizeProPhoto(bl)
+	return
+}
+
+// BlendProPhotoRgb blends two colors in the ProPhoto RGB color-space.
+// t == 0 results in c1, t == 1 results in c2
+func (c1 Color) BlendProPhotoRgb(c2 Color, t float64) Color {
+	r1, g1, b1 := c1.ProPhotoRgb()
+	r2, g2, b2 := c2.ProPhotoRgb()
+	return ProPhotoRgb(
+		r1+t*(r2-r1),
+		g1+t*(g2-g1),
+		b1+t*(b2-b1))
+}
+
+/// Rec. 2020 ///
+/////////////////
+// ITU-R BT.2020 color space.
+
+const (
+	rec2020Alpha = 1.09929682680944
+	rec2020Beta  = 0.018053968510807
+)
+
+func linearizeRec2020(v float64) float64 {
+	if v < rec2020Beta*4.5 {
+		return v / 4.5
+	}
+	return math.Pow((v+rec2020Alpha-1)/rec2020Alpha, 1.0/0.45)
+}
+
+func delinearizeRec2020(v float64) float64 {
+	if v < rec2020Beta {
+		return 4.5 * v
+	}
+	return rec2020Alpha*math.Pow(v, 0.45) - (rec2020Alpha - 1)
+}
+
+func Rec2020ToLinearRgb(r, g, b float64) (rl, gl, bl float64) {
+	rl = linearizeRec2020(r)
+	gl = linearizeRec2020(g)
+	bl = linearizeRec2020(b)
+	return
+}
+
+func LinearRec2020ToXyz(r, g, b float64) (x, y, z float64) {
+	x = 0.6369580483012914*r + 0.14461690358620832*g + 0.1688809751641721*b
+	y = 0.2627002120112671*r + 0.6779980715188708*g + 0.05930171646986196*b
+	z = 0.028072693049087428*g + 1.0609850577107909*b
+	return
+}
+
+func XyzToLinearRec2020(x, y, z float64) (r, g, b float64) {
+	r = 1.7166511879712674*x - 0.35567078377639233*y - 0.25336628137365974*z
+	g = -0.666684351832489*x + 1.616481236634939*y + 0.0157685458139402*z
+	b = 0.017639857445310783*x - 0.042770613257808524*y + 0.9421031212354738*z
+	return
+}
+
+func Rec2020(r, g, b float64) Color {
+	rl, gl, bl := Rec2020ToLinearRgb(r, g, b)
+	x, y, z := LinearRec2020ToXyz(rl, gl, bl)
+	return Xyz(x, y, z)
+}
+
+func (col Color) Rec2020() (r, g, b float64) {
+	x, y, z := col.Xyz()
+	rl, gl, bl := XyzToLinearRec2020(x, y, z)
+	r = delinearizeRec2020(rl)
+	g = delinearizeRec2020(gl)
+	b = delinearizeRec2020(bl)
+	return
+}
+
+// BlendRec2020 blends two colors in the Rec. 2020 color-space.
+// t == 0 results in c1, t == 1 results in c2
+func (c1 Color) BlendRec2020(c2 Color, t float64) Color {
+	r1, g1, b1 := c1.Rec2020()
+	r2, g2, b2 := c2.Rec2020()
+	return Rec2020(
+		r1+t*(r2-r1),
+		g1+t*(g2-g1),
+		b1+t*(b2-b1))
+}

--- a/widegamut_test.go
+++ b/widegamut_test.go
@@ -1,0 +1,313 @@
+package colorful
+
+import (
+	"math"
+	"testing"
+)
+
+// Reference values computed using the CSS Color Level 4 spec's conversion code.
+// Each entry maps an sRGB color to its representation in each wide-gamut space.
+var widegamutVals = []struct {
+	c        Color
+	displayP3  [3]float64
+	a98Rgb     [3]float64
+	proPhoto   [3]float64
+	rec2020    [3]float64
+	xyzD50     [3]float64
+}{
+	// White
+	{Color{1.0, 1.0, 1.0},
+		[3]float64{1.0, 1.0, 1.0},
+		[3]float64{1.0, 1.0, 1.0},
+		[3]float64{1.0, 1.0, 1.0},
+		[3]float64{1.0, 1.0, 1.0},
+		[3]float64{0.9642200, 1.0000000, 0.8251900},
+	},
+	// Black
+	{Color{0.0, 0.0, 0.0},
+		[3]float64{0.0, 0.0, 0.0},
+		[3]float64{0.0, 0.0, 0.0},
+		[3]float64{0.0, 0.0, 0.0},
+		[3]float64{0.0, 0.0, 0.0},
+		[3]float64{0.0, 0.0, 0.0},
+	},
+}
+
+/// Roundtrip tests ///
+///////////////////////
+// Encode sRGB -> space -> sRGB and verify identity within tolerance.
+
+func TestDisplayP3Roundtrip(t *testing.T) {
+	for _, tt := range vals {
+		r, g, b := tt.c.DisplayP3()
+		c := DisplayP3(r, g, b)
+		if !c.AlmostEqualRgb(tt.c) {
+			t.Errorf("%v -> DisplayP3 -> sRGB = %v, want %v", tt.c, c, tt.c)
+		}
+	}
+}
+
+func TestA98RgbRoundtrip(t *testing.T) {
+	for _, tt := range vals {
+		r, g, b := tt.c.A98Rgb()
+		c := A98Rgb(r, g, b)
+		if !c.AlmostEqualRgb(tt.c) {
+			t.Errorf("%v -> A98Rgb -> sRGB = %v, want %v", tt.c, c, tt.c)
+		}
+	}
+}
+
+func TestProPhotoRgbRoundtrip(t *testing.T) {
+	for _, tt := range vals {
+		r, g, b := tt.c.ProPhotoRgb()
+		c := ProPhotoRgb(r, g, b)
+		if !c.AlmostEqualRgb(tt.c) {
+			t.Errorf("%v -> ProPhotoRgb -> sRGB = %v, want %v", tt.c, c, tt.c)
+		}
+	}
+}
+
+func TestRec2020Roundtrip(t *testing.T) {
+	for _, tt := range vals {
+		r, g, b := tt.c.Rec2020()
+		c := Rec2020(r, g, b)
+		if !c.AlmostEqualRgb(tt.c) {
+			t.Errorf("%v -> Rec2020 -> sRGB = %v, want %v", tt.c, c, tt.c)
+		}
+	}
+}
+
+func TestXyzD50Roundtrip(t *testing.T) {
+	for _, tt := range vals {
+		x, y, z := tt.c.XyzD50()
+		c := XyzD50(x, y, z)
+		if !c.AlmostEqualRgb(tt.c) {
+			t.Errorf("%v -> XyzD50 -> sRGB = %v, want %v", tt.c, c, tt.c)
+		}
+	}
+}
+
+/// Bradford adaptation roundtrip ///
+/////////////////////////////////////
+
+func TestBradfordRoundtrip(t *testing.T) {
+	for _, tt := range vals {
+		x, y, z := tt.c.Xyz()
+		x50, y50, z50 := D65ToD50(x, y, z)
+		x65, y65, z65 := D50ToD65(x50, y50, z50)
+		if !almosteq(x, x65) || !almosteq(y, y65) || !almosteq(z, z65) {
+			t.Errorf("Bradford roundtrip: (%v,%v,%v) -> D50 -> D65 = (%v,%v,%v)", x, y, z, x65, y65, z65)
+		}
+	}
+}
+
+/// Reference value tests ///
+/////////////////////////////
+
+func TestDisplayP3WhiteBlack(t *testing.T) {
+	for i, tt := range widegamutVals {
+		r, g, b := tt.c.DisplayP3()
+		if !almosteq(r, tt.displayP3[0]) || !almosteq(g, tt.displayP3[1]) || !almosteq(b, tt.displayP3[2]) {
+			t.Errorf("%v. %v.DisplayP3() => (%v, %v, %v), want %v", i, tt.c, r, g, b, tt.displayP3)
+		}
+	}
+}
+
+func TestA98RgbWhiteBlack(t *testing.T) {
+	for i, tt := range widegamutVals {
+		r, g, b := tt.c.A98Rgb()
+		if !almosteq(r, tt.a98Rgb[0]) || !almosteq(g, tt.a98Rgb[1]) || !almosteq(b, tt.a98Rgb[2]) {
+			t.Errorf("%v. %v.A98Rgb() => (%v, %v, %v), want %v", i, tt.c, r, g, b, tt.a98Rgb)
+		}
+	}
+}
+
+func TestProPhotoRgbWhiteBlack(t *testing.T) {
+	for i, tt := range widegamutVals {
+		r, g, b := tt.c.ProPhotoRgb()
+		if !almosteq(r, tt.proPhoto[0]) || !almosteq(g, tt.proPhoto[1]) || !almosteq(b, tt.proPhoto[2]) {
+			t.Errorf("%v. %v.ProPhotoRgb() => (%v, %v, %v), want %v", i, tt.c, r, g, b, tt.proPhoto)
+		}
+	}
+}
+
+func TestRec2020WhiteBlack(t *testing.T) {
+	for i, tt := range widegamutVals {
+		r, g, b := tt.c.Rec2020()
+		if !almosteq(r, tt.rec2020[0]) || !almosteq(g, tt.rec2020[1]) || !almosteq(b, tt.rec2020[2]) {
+			t.Errorf("%v. %v.Rec2020() => (%v, %v, %v), want %v", i, tt.c, r, g, b, tt.rec2020)
+		}
+	}
+}
+
+func TestXyzD50WhiteBlack(t *testing.T) {
+	for i, tt := range widegamutVals {
+		x, y, z := tt.c.XyzD50()
+		if !almosteq(x, tt.xyzD50[0]) || !almosteq(y, tt.xyzD50[1]) || !almosteq(z, tt.xyzD50[2]) {
+			t.Errorf("%v. %v.XyzD50() => (%v, %v, %v), want %v", i, tt.c, x, y, z, tt.xyzD50)
+		}
+	}
+}
+
+/// Transfer function tests ///
+///////////////////////////////
+
+func TestA98TransferRoundtrip(t *testing.T) {
+	for v := 0.0; v <= 1.0; v += 0.01 {
+		lin := linearizeA98(v)
+		back := delinearizeA98(lin)
+		if math.Abs(v-back) > 1e-10 {
+			t.Errorf("A98 transfer roundtrip: %v -> %v -> %v", v, lin, back)
+		}
+	}
+}
+
+func TestProPhotoTransferRoundtrip(t *testing.T) {
+	for v := 0.0; v <= 1.0; v += 0.01 {
+		lin := linearizeProPhoto(v)
+		back := delinearizeProPhoto(lin)
+		if math.Abs(v-back) > 1e-10 {
+			t.Errorf("ProPhoto transfer roundtrip: %v -> %v -> %v", v, lin, back)
+		}
+	}
+}
+
+func TestRec2020TransferRoundtrip(t *testing.T) {
+	for v := 0.0; v <= 1.0; v += 0.01 {
+		lin := linearizeRec2020(v)
+		back := delinearizeRec2020(lin)
+		if math.Abs(v-back) > 1e-10 {
+			t.Errorf("Rec2020 transfer roundtrip: %v -> %v -> %v", v, lin, back)
+		}
+	}
+}
+
+/// sRGB primary roundtrip through each space ///
+//////////////////////////////////////////////////
+// sRGB red, green, blue through each wide-gamut space.
+
+func TestSRGBPrimariesDisplayP3(t *testing.T) {
+	primaries := []Color{
+		{1, 0, 0},
+		{0, 1, 0},
+		{0, 0, 1},
+	}
+	for _, c := range primaries {
+		r, g, b := c.DisplayP3()
+		back := DisplayP3(r, g, b)
+		if !back.AlmostEqualRgb(c) {
+			t.Errorf("sRGB primary %v through DisplayP3 (%v,%v,%v) = %v", c, r, g, b, back)
+		}
+	}
+}
+
+func TestSRGBPrimariesA98Rgb(t *testing.T) {
+	primaries := []Color{
+		{1, 0, 0},
+		{0, 1, 0},
+		{0, 0, 1},
+	}
+	for _, c := range primaries {
+		r, g, b := c.A98Rgb()
+		back := A98Rgb(r, g, b)
+		if !back.AlmostEqualRgb(c) {
+			t.Errorf("sRGB primary %v through A98Rgb (%v,%v,%v) = %v", c, r, g, b, back)
+		}
+	}
+}
+
+func TestSRGBPrimariesProPhotoRgb(t *testing.T) {
+	primaries := []Color{
+		{1, 0, 0},
+		{0, 1, 0},
+		{0, 0, 1},
+	}
+	for _, c := range primaries {
+		r, g, b := c.ProPhotoRgb()
+		back := ProPhotoRgb(r, g, b)
+		if !back.AlmostEqualRgb(c) {
+			t.Errorf("sRGB primary %v through ProPhotoRgb (%v,%v,%v) = %v", c, r, g, b, back)
+		}
+	}
+}
+
+func TestSRGBPrimariesRec2020(t *testing.T) {
+	primaries := []Color{
+		{1, 0, 0},
+		{0, 1, 0},
+		{0, 0, 1},
+	}
+	for _, c := range primaries {
+		r, g, b := c.Rec2020()
+		back := Rec2020(r, g, b)
+		if !back.AlmostEqualRgb(c) {
+			t.Errorf("sRGB primary %v through Rec2020 (%v,%v,%v) = %v", c, r, g, b, back)
+		}
+	}
+}
+
+/// Blend endpoint tests ///
+////////////////////////////
+
+func TestBlendDisplayP3Endpoints(t *testing.T) {
+	c1, _ := Hex("#1a1a46")
+	c2, _ := Hex("#666666")
+	if b := c1.BlendDisplayP3(c2, 0).Hex(); b != c1.Hex() {
+		t.Errorf("BlendDisplayP3 t=0: got %v, want %v", b, c1.Hex())
+	}
+	if b := c1.BlendDisplayP3(c2, 1).Hex(); b != c2.Hex() {
+		t.Errorf("BlendDisplayP3 t=1: got %v, want %v", b, c2.Hex())
+	}
+}
+
+func TestBlendA98RgbEndpoints(t *testing.T) {
+	c1, _ := Hex("#1a1a46")
+	c2, _ := Hex("#666666")
+	if b := c1.BlendA98Rgb(c2, 0).Hex(); b != c1.Hex() {
+		t.Errorf("BlendA98Rgb t=0: got %v, want %v", b, c1.Hex())
+	}
+	if b := c1.BlendA98Rgb(c2, 1).Hex(); b != c2.Hex() {
+		t.Errorf("BlendA98Rgb t=1: got %v, want %v", b, c2.Hex())
+	}
+}
+
+func TestBlendProPhotoRgbEndpoints(t *testing.T) {
+	c1, _ := Hex("#1a1a46")
+	c2, _ := Hex("#666666")
+	if b := c1.BlendProPhotoRgb(c2, 0).Hex(); b != c1.Hex() {
+		t.Errorf("BlendProPhotoRgb t=0: got %v, want %v", b, c1.Hex())
+	}
+	if b := c1.BlendProPhotoRgb(c2, 1).Hex(); b != c2.Hex() {
+		t.Errorf("BlendProPhotoRgb t=1: got %v, want %v", b, c2.Hex())
+	}
+}
+
+func TestBlendRec2020Endpoints(t *testing.T) {
+	c1, _ := Hex("#1a1a46")
+	c2, _ := Hex("#666666")
+	if b := c1.BlendRec2020(c2, 0).Hex(); b != c1.Hex() {
+		t.Errorf("BlendRec2020 t=0: got %v, want %v", b, c1.Hex())
+	}
+	if b := c1.BlendRec2020(c2, 1).Hex(); b != c2.Hex() {
+		t.Errorf("BlendRec2020 t=1: got %v, want %v", b, c2.Hex())
+	}
+}
+
+/// XYZ D50 consistency with existing Lab D50 ///
+/////////////////////////////////////////////////
+// XyzD50 should produce values consistent with the existing D50 white point.
+
+func TestXyzD50ConsistentWithLabD50(t *testing.T) {
+	// Convert sRGB white to XYZ D50 and verify it matches the D50 white point
+	x, y, z := Color{1, 1, 1}.XyzD50()
+	if !almosteq(y, 1.0) {
+		t.Errorf("White XYZ D50 Y = %v, want 1.0", y)
+	}
+	// D50 white point ratios should be close to the defined D50 constant
+	if !almosteq_eps(x/y, D50[0]/D50[1], 0.005) {
+		t.Errorf("White XYZ D50 x/y = %v, want ~%v", x/y, D50[0]/D50[1])
+	}
+	if !almosteq_eps(z/y, D50[2]/D50[1], 0.005) {
+		t.Errorf("White XYZ D50 z/y = %v, want ~%v", z/y, D50[2]/D50[1])
+	}
+}


### PR DESCRIPTION
## Summary

- Add constructors, decomposers, and blend functions for the four wide-gamut RGB color spaces from the CSS Color Level 4 `color()` function
- Add XYZ D50 as a first-class color space with Bradford chromatic adaptation

### New color spaces

- **Display P3** - sRGB transfer function, DCI-P3 primaries
- **A98 RGB** - Adobe RGB (1998)
- **ProPhoto RGB** - ROMM RGB, D50 illuminant with Bradford adaptation
- **Rec. 2020** - ITU-R BT.2020

### New API

```go
// Constructors and decomposers (same pattern as LinearRgb/Xyz/OkLab)
DisplayP3(r, g, b) / (Color).DisplayP3()
A98Rgb(r, g, b) / (Color).A98Rgb()
ProPhotoRgb(r, g, b) / (Color).ProPhotoRgb()
Rec2020(r, g, b) / (Color).Rec2020()
XyzD50(x, y, z) / (Color).XyzD50()

// Bradford chromatic adaptation
D50ToD65(x, y, z) / D65ToD50(x, y, z)

// Intermediate conversion functions
LinearDisplayP3ToXyz / XyzToLinearDisplayP3 / DisplayP3ToLinearRgb
LinearA98RgbToXyz / XyzToLinearA98Rgb / A98RgbToLinearRgb
LinearProPhotoRgbToXyzD50 / XyzD50ToLinearProPhotoRgb / ProPhotoRgbToLinearRgb
LinearRec2020ToXyz / XyzToLinearRec2020 / Rec2020ToLinearRgb

// Blend functions
BlendDisplayP3 / BlendA98Rgb / BlendProPhotoRgb / BlendRec2020
```

All matrices and transfer functions come from the CSS Color Level 4 spec:
https://www.w3.org/TR/css-color-4/#color-conversion-code

## Motivation

I maintain [asimonim](https://github.com/bennypowers/asimonim), a design token CLI that converts DTCG tokens across formats. When converting to Android XML (which only accepts hex colors), I need to downsample wide-gamut colors to sRGB. I already use go-colorful for XYZ-to-sRGB conversion, but had to hand-roll the transfer functions and primaries-to-XYZ matrices for these four CSS `color()` spaces (see [asimonim PR #28](https://github.com/bennypowers/asimonim/pull/28)). This PR upstreams those conversions so other consumers don't have to duplicate the work.

## Test plan

- [x] Roundtrip tests for all 5 spaces through the existing 15-color `vals` table
- [x] Bradford adaptation roundtrip
- [x] White/black reference value tests
- [x] Transfer function roundtrip for A98, ProPhoto, Rec2020
- [x] sRGB primary roundtrip through each space
- [x] Blend endpoint tests (t=0, t=1)
- [x] XYZ D50 consistency with existing D50 white point constant
- [x] 100% coverage on all new code
- [x] All existing tests pass, no regressions
- [x] Clean: `go vet`, `golangci-lint`, `staticcheck`
- [x] Care was taken to match existing code style

Closes #81