### PR TITLE
HexColor: fmt.Stringer interface support

### DIFF
--- a/hexcolor.go
+++ b/hexcolor.go
@@ -34,6 +34,10 @@ func (hc *HexColor) Value() (driver.Value, error) {
 	return Color(*hc).Hex(), nil
 }
 
+func (hc HexColor) String() string {
+	return Color(hc).Hex()
+}
+
 func (e errUnsupportedType) Error() string {
 	return fmt.Sprintf("unsupported type: got %v, want a %s", e.got, e.want)
 }

--- a/hexcolor_test.go
+++ b/hexcolor_test.go
@@ -27,6 +27,10 @@ func TestHexColor(t *testing.T) {
 		if gotValue, err := tc.hc.Value(); err != nil || !reflect.DeepEqual(gotValue, tc.s) {
 			t.Errorf("%v.Value() == %v, %v, want %v, <nil>", tc.hc, gotValue, err, tc.s)
 		}
+		gotString := tc.hc.String()
+		if !reflect.DeepEqual(gotString, tc.s) {
+			t.Errorf("_.String() == %v, want %v", gotString, tc.s)
+		}
 	}
 }
 


### PR DESCRIPTION
## Changelog
### Added
- `HexColor` implements `fmt.Stringer` interface

## Motivation
To log or serialise HexColor as a string without uses the extra Hex() method. Useful with [pgx](https://github.com/jackc/pgx) lib.

Closes https://github.com/lucasb-eyer/go-colorful/issues/83