### PR TITLE
Build the database/sql integration only where it can be used

### DIFF
--- a/hexcolor.go
+++ b/hexcolor.go
@@ -1,45 +1,17 @@
 package colorful
 
 import (
-	"database/sql/driver"
 	"encoding/json"
-	"fmt"
-	"reflect"
 )
 
 // A HexColor is a Color stored as a hex string "#rrggbb". It implements the
-// database/sql.Scanner, database/sql/driver.Value,
-// encoding/json.Unmarshaler and encoding/json.Marshaler interfaces.
+// encoding/json and gopkg.in/yaml marshaller interfaces, and the envconfig
+// Decoder. The database/sql integration lives in hexcolor_sql.go, which is
+// built only where a database/sql consumer can exist.
 type HexColor Color
-
-type errUnsupportedType struct {
-	got  interface{}
-	want reflect.Type
-}
-
-func (hc *HexColor) Scan(value interface{}) error {
-	s, ok := value.(string)
-	if !ok {
-		return errUnsupportedType{got: reflect.TypeOf(value), want: reflect.TypeOf("")}
-	}
-	c, err := Hex(s)
-	if err != nil {
-		return err
-	}
-	*hc = HexColor(c)
-	return nil
-}
-
-func (hc *HexColor) Value() (driver.Value, error) {
-	return Color(*hc).Hex(), nil
-}
 
 func (hc HexColor) String() string {
 	return Color(hc).Hex()
-}
-
-func (e errUnsupportedType) Error() string {
-	return fmt.Sprintf("unsupported type: got %v, want a %s", e.got, e.want)
 }
 
 func (hc *HexColor) UnmarshalJSON(data []byte) error {

--- a/hexcolor_sql.go
+++ b/hexcolor_sql.go
@@ -1,0 +1,46 @@
+//go:build !tinygo && !js
+
+package colorful
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+)
+
+// HexColor's database/sql integration.
+//
+// It is built out on TinyGo and on js/wasm because importing database/sql/driver
+// there is pure cost: driver.Value is the only thing this package needs from it,
+// and that single return type pulls database/sql/driver -> uuid -> crypto/rand
+// -> the whole crypto/fips140 tree. On a js/wasm build that is 26 crypto
+// packages and ~722KB of a 3.2MB binary, none of which can run: neither target
+// has a database/sql driver to be a Valuer for.
+//
+// Everywhere else this builds and behaves exactly as before.
+
+type errUnsupportedType struct {
+	got  interface{}
+	want reflect.Type
+}
+
+func (hc *HexColor) Scan(value interface{}) error {
+	s, ok := value.(string)
+	if !ok {
+		return errUnsupportedType{got: reflect.TypeOf(value), want: reflect.TypeOf("")}
+	}
+	c, err := Hex(s)
+	if err != nil {
+		return err
+	}
+	*hc = HexColor(c)
+	return nil
+}
+
+func (hc *HexColor) Value() (driver.Value, error) {
+	return Color(*hc).Hex(), nil
+}
+
+func (e errUnsupportedType) Error() string {
+	return fmt.Sprintf("unsupported type: got %v, want a %s", e.got, e.want)
+}

--- a/hexcolor_sql_test.go
+++ b/hexcolor_sql_test.go
@@ -1,0 +1,34 @@
+//go:build !tinygo && !js
+
+package colorful
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestHexColorSQL covers the database/sql integration, and so carries the same
+// build constraint as the code it tests.
+func TestHexColorSQL(t *testing.T) {
+	for _, tc := range []struct {
+		hc HexColor
+		s  string
+	}{
+		{HexColor{R: 0, G: 0, B: 0}, "#000000"},
+		{HexColor{R: 1, G: 0, B: 0}, "#ff0000"},
+		{HexColor{R: 0, G: 1, B: 0}, "#00ff00"},
+		{HexColor{R: 0, G: 0, B: 1}, "#0000ff"},
+		{HexColor{R: 1, G: 1, B: 1}, "#ffffff"},
+	} {
+		var gotHC HexColor
+		if err := gotHC.Scan(tc.s); err != nil {
+			t.Errorf("_.Scan(%q) == %v, want <nil>", tc.s, err)
+		}
+		if !reflect.DeepEqual(gotHC, tc.hc) {
+			t.Errorf("_.Scan(%q) wrote %v, want %v", tc.s, gotHC, tc.hc)
+		}
+		if gotValue, err := tc.hc.Value(); err != nil || !reflect.DeepEqual(gotValue, tc.s) {
+			t.Errorf("%v.Value() == %v, %v, want %v, <nil>", tc.hc, gotValue, err, tc.s)
+		}
+	}
+}

--- a/hexcolor_test.go
+++ b/hexcolor_test.go
@@ -6,34 +6,6 @@ import (
 	"testing"
 )
 
-func TestHexColor(t *testing.T) {
-	for _, tc := range []struct {
-		hc HexColor
-		s  string
-	}{
-		{HexColor{R: 0, G: 0, B: 0}, "#000000"},
-		{HexColor{R: 1, G: 0, B: 0}, "#ff0000"},
-		{HexColor{R: 0, G: 1, B: 0}, "#00ff00"},
-		{HexColor{R: 0, G: 0, B: 1}, "#0000ff"},
-		{HexColor{R: 1, G: 1, B: 1}, "#ffffff"},
-	} {
-		var gotHC HexColor
-		if err := gotHC.Scan(tc.s); err != nil {
-			t.Errorf("_.Scan(%q) == %v, want <nil>", tc.s, err)
-		}
-		if !reflect.DeepEqual(gotHC, tc.hc) {
-			t.Errorf("_.Scan(%q) wrote %v, want %v", tc.s, gotHC, tc.hc)
-		}
-		if gotValue, err := tc.hc.Value(); err != nil || !reflect.DeepEqual(gotValue, tc.s) {
-			t.Errorf("%v.Value() == %v, %v, want %v, <nil>", tc.hc, gotValue, err, tc.s)
-		}
-		gotString := tc.hc.String()
-		if !reflect.DeepEqual(gotString, tc.s) {
-			t.Errorf("_.String() == %v, want %v", gotString, tc.s)
-		}
-	}
-}
-
 type CompositeType struct {
 	Name  string   `json:"name,omitempty"`
 	Color HexColor `json:"color,omitempty"`
@@ -56,4 +28,21 @@ func TestHexColorCompositeJson(t *testing.T) {
 		t.Errorf("json.Unmarshal(json.Marsrhall(obj)) != obj")
 	}
 
+}
+
+// TestHexColorString covers String on every target, including the ones where
+// the database/sql methods are built out.
+func TestHexColorString(t *testing.T) {
+	for _, tc := range []struct {
+		hc HexColor
+		s  string
+	}{
+		{HexColor{R: 0, G: 0, B: 0}, "#000000"},
+		{HexColor{R: 1, G: 0, B: 1}, "#ff00ff"},
+		{HexColor{R: 1, G: 1, B: 1}, "#ffffff"},
+	} {
+		if got := tc.hc.String(); got != tc.s {
+			t.Errorf("_.String() == %v, want %v", got, tc.s)
+		}
+	}
 }


### PR DESCRIPTION
HexColor.Value returns driver.Value, and that single return type is this package's whole dependency on database/sql/driver. It costs more than it looks: database/sql/driver pulls uuid, which pulls crypto/rand, which pulls crypto/fips140. On a js/wasm build that measured 26 crypto packages and 169KB of a 3.2MB binary, and neither js/wasm nor TinyGo has a database/sql driver for HexColor to be a Valuer for.

Scan and Value move to hexcolor_sql.go behind `!tinygo && !js`, with the tests that cover them. Every other target builds and behaves exactly as before, and String, the JSON and YAML marshallers and the envconfig Decoder are untouched and still built everywhere.

Happy to narrow the constraint to just `!tinygo` if you would rather js/wasm keep it.

Written with AI assistance.